### PR TITLE
Block types, get events

### DIFF
--- a/examples/examples/block_events.rs
+++ b/examples/examples/block_events.rs
@@ -1,0 +1,21 @@
+use libuptest::ws_mod::get_block_events;
+use libuptest::jsonrpseeclient::JsonrpseeClient;
+use libuptest::types::{H256, PreBlock};
+
+
+use std::str::FromStr;
+
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    println!("function started");
+    let polkadot_dial = JsonrpseeClient::polkadot_default_url().unwrap();
+    println!("Connection established");
+    let mablock: H256 = H256::from_str("0x453604c1547d86e467d544b5e931e2ed09d966f19c3783923042ae453394cdcd")?;
+    println!("mablock ok");
+    let _output: PreBlock = get_block_events(mablock, polkadot_dial).await.unwrap();
+    println!("got output!");
+    println!("function passed, output:");
+    Ok(())
+}
+

--- a/examples/examples/metadata_version.rs
+++ b/examples/examples/metadata_version.rs
@@ -25,6 +25,7 @@ async fn main() -> anyhow::Result<()> {
     let edg_version: u8 = get_metadata_version(dial_edg.clone()).await.unwrap(); // yolo unwrap
     println!("Connected to chain: {:?} and got metadata version: {:?}", "Edgeware", edg_version);
     let finalized_block_hash: H256 = get_latest_finalized_head(dial_edg).await.unwrap();
+    let str_it = format!("{:?}", finalized_block_hash);
     println!("The latest finalized head is: {:?}", finalized_block_hash);
     
     Ok(())

--- a/libuptest/src/error.rs
+++ b/libuptest/src/error.rs
@@ -13,7 +13,10 @@ pub enum Error {
 	InvalidUrl(String),
 	RecvError(String),
 	Io(String),
+	Stderror(String),
+
 	HexError(hex::FromHexError),
+	FixedHashHexError(fixed_hash::rustc_hex::FromHexError),
 	MaxConnectionAttemptsExceeded,
 	/// connection to endpoint closed
 	ConnectionClosed,
@@ -23,9 +26,7 @@ pub enum Error {
 	Unsubscribefail,
 	AsyncNextError,
 	ConnectionSubscriptionProblem,
-	//Other(Box<dyn core::error::Error + Send + Sync + 'static>),
 	Client(Box<dyn core::error::Error + Send + Sync + 'static>),
-//	Client(Box<dyn core::error::Error + Send + Sync + 'static>),
 }
 
 
@@ -40,4 +41,20 @@ impl From<hex::FromHexError> for Error {
 	fn from(value: hex::FromHexError) -> Self {
 		Self::HexError(value)
 	}
+}
+
+// fixed-hash hex error
+impl From<fixed_hash::rustc_hex::FromHexError> for Error {
+	fn from(value: fixed_hash::rustc_hex::FromHexError) -> Self {
+		Self::FixedHashHexError(value)
+	}
+}
+
+
+// 
+impl From<&dyn std::error::Error> for Error {
+	fn from(error: &dyn std::error::Error) -> Self {
+		Self::Stderror(format!("{error:?}"))
+	}
+
 }

--- a/libuptest/src/jsonrpseeclient/rpcstuff.rs
+++ b/libuptest/src/jsonrpseeclient/rpcstuff.rs
@@ -138,4 +138,21 @@ impl ParamsBuilder {
 }
 
 
+// this function was written by parity
+#[macro_export]
+macro_rules! rpc_params {
+	($($param:expr),*) => {
+		{
+
+			let mut params = RpcParams::new();
+			$(
+				if let Err(err) = params.insert($param) {
+					panic!("Parameter `{}` cannot be serialized: {:?}", stringify!($param), err);
+				}
+			)*
+			params
+		}
+	};
+}
+
 

--- a/libuptest/src/types.rs
+++ b/libuptest/src/types.rs
@@ -1,5 +1,4 @@
 use fixed_hash::construct_fixed_hash;
-//use std::str::FromStr;
 use serde::{Serialize, Deserialize};
 
 
@@ -10,8 +9,31 @@ construct_fixed_hash! {
 }
 
 
-// used for subscribing to finalized head
+/// todo add the cargo expand
+
+
 #[derive(Debug, Deserialize)]
 pub struct Header {
     pub number: String,
 }
+
+/// generic substrate sp-runtime block
+#[derive(Debug, Deserialize)]
+pub struct Block<Header, Extrinsic: Serialize> {
+    pub header: Header,
+    pub extrinsics: Extrinsic,//Vec<String>    
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct justifications(Vec<u8>);
+
+// what we get if 
+#[derive(Debug, Deserialize)]
+pub struct PreBlock{
+    pub block: generic_block,
+    
+    pub justifications: Option<justifications>,//Justification can be null so lets put this in an option
+}
+
+
+pub type generic_block = Block<Header, Vec<String>>;

--- a/libuptest/src/ws_mod.rs
+++ b/libuptest/src/ws_mod.rs
@@ -1,11 +1,13 @@
 pub use jsonrpsee::ws_client::{WsClientBuilder, WsClient};
 //use crate::error;
 //use crate::jsonrpseeclient::rpcstuff::*;
+use crate::rpc_params;
+use std::str::FromStr;
 use crate::jsonrpseeclient::rpcstuff::RpcParams;
 use crate::jsonrpseeclient::JsonrpseeClient;
 use crate::jsonrpseeclient::subscription::Request;
-use crate::types::H256;
-use std::str::FromStr;
+use crate::types::{H256, PreBlock};
+
 
 pub struct Wsclientwrapper();
 
@@ -54,11 +56,22 @@ pub async fn get_latest_finalized_head(client: JsonrpseeClient) -> anyhow::Resul
 #[maybe_async::maybe_async(?Send)]
 pub async fn get_latest_finalized_head(client: JsonrpseeClient) -> anyhow::Result<H256, crate::error::Error> {
     let hex_data: String = client.request("chain_getFinalizedHead", RpcParams::new()).await?;
-    let finb: H256 = H256::from_str(&hex_data.as_str()).unwrap();
+    let finb: H256 = H256::from_str(&hex_data.as_str())?;
     Ok(finb) 
 }
 
 
+
+
+#[maybe_async::maybe_async(?Send)]
+pub async fn get_block_events(blockhash: H256, client: JsonrpseeClient) -> anyhow::Result<PreBlock, crate::error::Error> {
+    let string_hash: String = format!("{:?}", blockhash);
+ //   let query: Vec<String> = client.request("chain_getBlock",  rpc_params!["0x11dc73c97be314034507df6ceb80a3f4e15aa0d04f2a7f148e076e68e5341f96"]).await?; //rpc_params![].into()
+   
+    let qq: PreBlock = client.request("chain_getBlock",  rpc_params![string_hash]).await?; //rpc_params![].into()
+    //let fluff: Vec<String> = vec!["fluff".to_string()];
+    Ok(qq)
+}
 
 /*
 /// get block nr and system block events


### PR DESCRIPTION
get block events, support blocktypes, fixed null bug with options, block_events.rs example file, added block and header types, rpc_params exported to onfile-macro