### PR TITLE
v0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "libuptest"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4656,7 +4656,7 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "uptest"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -4668,7 +4668,7 @@ dependencies = [
 
 [[package]]
 name = "uptest-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uptest"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/uptest-sc/uptest/"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ https://github.com/users/uptest-sc/projects/1/views/1
 
 ### Examples   
 
+Run examples:  
+```shell
+$ sh run_example.sh
+```
+
 #### Get metadata version:   
 ```rust
 use libuptest::jsonrpseeclient::JsonrpseeClient;

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uptest-cli"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/uptest-sc/uptest/"

--- a/examples/examples/block_events.rs
+++ b/examples/examples/block_events.rs
@@ -11,18 +11,18 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 use libuptest::jsonrpseeclient::JsonrpseeClient;
 use libuptest::types::{PreBlock, H256};
 use libuptest::ws_mod::get_block_events;
-
+use libuptest::error::Error;
 use std::str::FromStr;
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> anyhow::Result<(), Error> {
     println!("function started");
-    let polkadot_dial = JsonrpseeClient::polkadot_default_url().unwrap();
+    let polkadot_dial = JsonrpseeClient::polkadot_default_url()?;
     println!("Connection established");
     let mablock: H256 =
         H256::from_str("0x8784cba4254c3800f502b0732b0260d0dee3b85701e8cbbd45bdddb7d3d2d5bf")?;
     println!("mablock ok");
-    let output: PreBlock = get_block_events(mablock, polkadot_dial).await.unwrap();
+    let output: PreBlock = get_block_events(mablock, polkadot_dial).await?;
     println!("got output: {:?}", output);
     println!("Block Nr: {:?}", output.block.header.number);
     println!("function passed, output:");

--- a/examples/examples/chain_info.rs
+++ b/examples/examples/chain_info.rs
@@ -11,12 +11,13 @@ State Version: 1
 */
 use libuptest::types::RuntimeVersion;
 use libuptest::ws_mod::get_runtime_version;
+use libuptest::error::Error;
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> anyhow::Result<(), Error> {
     // chain at 127.0.0.1:9944
-    let client = JsonrpseeClient::with_default_url().unwrap();
-    let chain_info: RuntimeVersion = get_runtime_version(client).await.unwrap();
+    let client = JsonrpseeClient::with_default_url()?;
+    let chain_info: RuntimeVersion = get_runtime_version(client).await?;
     println!("----Chain-Info----");
     println!(
         "Chain Name: {:?}

--- a/examples/examples/decode_extrinsics.rs
+++ b/examples/examples/decode_extrinsics.rs
@@ -12,15 +12,17 @@ use libuptest::decode_extrinsic::decode_extrinsic_hex_string;
 use libuptest::jsonrpseeclient::JsonrpseeClient;
 use libuptest::types::event_summary;
 use libuptest::ws_mod::get_raw_metadata;
+use libuptest::error::Error;
+
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> anyhow::Result<(), Error> {
     let raw_extrinsic = "0x280403000ba0ada8438801"; // time stamp extrinsic taken from random polkadot block
     println!("Raw extrinsic value: {raw_extrinsic:?}");
     println!("Downloading metadata");
-    let metadata: Vec<u8> = get_raw_metadata(JsonrpseeClient::polkadot_default_url().unwrap())
+    let metadata: Vec<u8> = get_raw_metadata(JsonrpseeClient::polkadot_default_url()?)
         .await
-        .unwrap(); // yolo
+        ?;
     println!("Metadata downloaded ok");
     let decoded_output = decode_extrinsic_hex_string(raw_extrinsic, &metadata);
     let single_event: event_summary = event_summary {

--- a/examples/examples/decode_transaction.rs
+++ b/examples/examples/decode_transaction.rs
@@ -1,0 +1,22 @@
+/// decode a transaction and display it in a nice human readable format
+
+/*
+struct supported_chains {
+    Edgeware: "",
+    Polkadot: "",
+    Hydradx: "",
+    Sora: ""
+}
+
+*/
+async fn tx_decode(network: String, tx: String) -> String {
+    "asd".to_string()
+}
+
+#[tokio::main]
+async fn main() {
+    let network = "hydradx";
+    let tx = "";
+    //let flufr = tx_decode(network, tx).await;
+    //   println!("GOt output: {:?}", flufr);
+}

--- a/examples/examples/detect_runtime_upgrade.rs
+++ b/examples/examples/detect_runtime_upgrade.rs
@@ -17,33 +17,32 @@ use libuptest::ws_mod::{
     get_block_events, get_decoded_extrinsics_from_blockhash, get_latest_finalized_head,
     get_raw_metadata, get_runtime_version,
 };
-//use std::str::FromStr;
-
+use libuptest::error::Error;
 // There are several ways of detecting a runtime upgrade, subscribing to each block, parsing each block for the runtime upgrade method to be executed or just probing for RuntimeVersion changes
 
 // todo check if migrations has been triggered
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> anyhow::Result<(), Error> {
     // different chains can customize the chain events, the default upgraded chain event is system.setCode
     let runtime_upgrade_event: event_summary = event_summary {
         pallet_name: "system".to_string(),
         pallet_method: "setCode".to_string(),
     }; // define the pallet name and method used to exectue to runtime upgrade, normally system codeupdate
-    let client: JsonrpseeClient = JsonrpseeClient::with_default_url().unwrap(); // change me
-    let metadatablob: Vec<u8> = get_raw_metadata(client.clone()).await.unwrap();
+    let client: JsonrpseeClient = JsonrpseeClient::with_default_url()?; // change me
+    let metadatablob: Vec<u8> = get_raw_metadata(client.clone()).await?;
     println!("Catching latest block");
-    let blockhash: H256 = get_latest_finalized_head(client.clone()).await.unwrap(); // get_latest_finalized_head(client.clone()).await.unwrap();//H256::from_str("0x89a5dde6705d345117f442dfacf02f4a59bf5cea3ab713a5c07fc4cd78be3a31").unwrap();//
+    let blockhash: H256 = get_latest_finalized_head(client.clone()).await?; // get_latest_finalized_head(client.clone()).await.unwrap();//H256::from_str("0x89a5dde6705d345117f442dfacf02f4a59bf5cea3ab713a5c07fc4cd78be3a31").unwrap();//
     println!("Got block hash: {blockhash:?}");
     println!("Gathering extrinsics inside block");
     let decodedevent_list: Vec<event_summary> =
         get_decoded_extrinsics_from_blockhash(blockhash, metadatablob.clone(), client.clone())
             .await
-            .unwrap();
+            ?;
     println!("List created");
     let contains_runtime_upgrade: bool = decodedevent_list.contains(&runtime_upgrade_event);
 
-    let outputen: PreBlock = get_block_events(blockhash, client.clone()).await.unwrap();
+    let outputen: PreBlock = get_block_events(blockhash, client.clone()).await?;
 
     for exti in outputen.block.extrinsics {
         let _printme = decode_extrinsic_hex_string(&exti, &metadatablob);
@@ -55,7 +54,7 @@ async fn main() -> anyhow::Result<()> {
         _ => println!("does not contain runtime upgrade"),
     }
     println!("Getting current runtime version");
-    let runtimeversion = get_runtime_version(client).await.unwrap();
+    let runtimeversion = get_runtime_version(client).await?;
     println!("Current runtime version: {:?}", runtimeversion.spec_version);
     Ok(())
 }

--- a/examples/examples/generate_pallet_tests.rs
+++ b/examples/examples/generate_pallet_tests.rs
@@ -6,13 +6,6 @@ use libuptest::pallet_storage_parse::{
 };
 use libuptest::test_helper::InputHelper;
 use libuptest::ws_mod::get_raw_metadata;
-use std::any::Any;
-use std::ops::Add;
-use std::os::linux::raw;
-
-async fn current_pallet_functions(pallet_name: String) -> Result<(), Error> {
-    Ok(())
-}
 
 /// convert typeid to raw type, supporting untracked symbols
 async fn track_it(typeid: u32, client: JsonrpseeClient) -> Result<(), Error> {
@@ -109,7 +102,7 @@ async fn main() -> anyhow::Result<(), Error> {
                 let name_type = test
                     .fields()
                     .first()
-                    .unwrap()
+                    .unwrap() // need fixing upstream
                     .type_name()
                     .ok_or(Error::StorageItemNotFound)?; // only does first, todo: fix this to an iterating solution
                 let outputt = format!(

--- a/examples/examples/get_pallet_storagemaps_storagevalues.rs
+++ b/examples/examples/get_pallet_storagemaps_storagevalues.rs
@@ -13,17 +13,19 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 use libuptest::jsonrpseeclient::JsonrpseeClient;
 use libuptest::pallet_storage_parse::{parse_pallet_storage_types, storage_map_info};
 use libuptest::ws_mod::get_raw_metadata;
+use libuptest::error::Error;
+
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Error> {
     println!("Starting");
-    let client = JsonrpseeClient::with_default_url().unwrap();
+    let client = JsonrpseeClient::with_default_url()?;
 
     // get the chain's metadata
-    let metadatablob = get_raw_metadata(client).await.unwrap();
+    let metadatablob = get_raw_metadata(client).await?;
 
     let pallet_list: Vec<storage_map_info> =
-        parse_pallet_storage_types(metadatablob).await.unwrap();
+        parse_pallet_storage_types(metadatablob).await?;
     println!("Amount of pallets:  {:?}", pallet_list.len());
     println!("looping throw loot");
     // /*
@@ -35,5 +37,5 @@ async fn main() {
 
     //  */
     println!("done");
-    //Ok(())
+    Ok(())
 }

--- a/examples/examples/metadata_version.rs
+++ b/examples/examples/metadata_version.rs
@@ -16,11 +16,11 @@ use libuptest::types::H256;
 use libuptest::ws_mod::{get_latest_finalized_head, get_metadata_version};
 //use libuptest::jsonrpseeclient::subscription::Request;
 //use libuptest::jsonrpseeclient::RpcParams;
-
+use libuptest::error::Error;
 //use jsonrpsee::ws_client::{WsClientBuilder, WsClient};
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> anyhow::Result<(), Error> {
     /*
     println!("Connecting to polkadot");
     let dial_polkadot = JsonrpseeClient::polkadot_default_url();
@@ -31,13 +31,13 @@ async fn main() -> anyhow::Result<()> {
     */
 
     println!("Connecting to Edgeware");
-    let dial_edg: JsonrpseeClient = JsonrpseeClient::edgeware_default_url().unwrap();
-    let edg_version: u8 = get_metadata_version(dial_edg.clone()).await.unwrap(); // yolo unwrap
+    let dial_edg: JsonrpseeClient = JsonrpseeClient::edgeware_default_url()?;
+    let edg_version: u8 = get_metadata_version(dial_edg.clone()).await?;
     println!(
         "Connected to chain: {:?} and got metadata version: {:?}",
         "Edgeware", edg_version
     );
-    let finalized_block_hash: H256 = get_latest_finalized_head(dial_edg).await.unwrap();
+    let finalized_block_hash: H256 = get_latest_finalized_head(dial_edg).await?;
     //   let str_it = format!("{:?}", finalized_block_hash);
     println!("The latest finalized head is: {:?}", finalized_block_hash);
 

--- a/examples/examples/migration_search_test.rs
+++ b/examples/examples/migration_search_test.rs
@@ -1,11 +1,11 @@
 //use std::fmt::format;
 use libuptest::migration_search::crates_io_search::{
-    download_crate_from_crates_io, search_crates_io, Crate, Crates,
+    download_crate_from_crates_io, search_crates_io, Crates,
 };
 use libuptest::migration_search::decompress::tar_xvf;
 use libuptest::migration_search::file_search::test_glob;
 
-pub struct mig_find {}
+pub struct MigFind {}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("docs are at: {:?}", results.documentation);
         // download crate to parent working dir
         let filen =
-            download_crate_from_crates_io(results.version.clone(), results.name.clone()).await?;
+            download_crate_from_crates_io(results.version.clone(), results.name.clone()).await.unwrap();
         println!("unziping file");
         let _unzip = tar_xvf(filen.clone());
         println!("file downloaded");

--- a/examples/examples/sample_test_rnu.rs
+++ b/examples/examples/sample_test_rnu.rs
@@ -13,23 +13,23 @@ use libuptest::decode_extrinsic::{decode_extrinsic_hex_string, decodec_to_event_
 use libuptest::jsonrpseeclient::JsonrpseeClient;
 use libuptest::types::{event_summary, H256};
 use libuptest::ws_mod::{get_block_events, get_raw_metadata};
-
+use libuptest::error::Error;
 use std::str::FromStr;
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> anyhow::Result<(), Error> {
     println!("Query single block for blockhash to check if it contains a runtime upgrade");
-    let client = JsonrpseeClient::with_default_url().unwrap(); // change me
-    let metadatablob = get_raw_metadata(client.clone()).await.unwrap();
+    let client = JsonrpseeClient::with_default_url()?; // change me
+    let metadatablob = get_raw_metadata(client.clone()).await?;
 
     // manually pushed a runtime upgrade and copy the block with the block events
     let blockhash: H256 =
         H256::from_str("0x89a5dde6705d345117f442dfacf02f4a59bf5cea3ab713a5c07fc4cd78be3a31")
-            .unwrap(); //get_latest_finalized_head(client.clone()).await.unwrap();
+            ?; //get_latest_finalized_head(client.clone()).await.unwrap();
 
     println!("Got block hash: {blockhash:?}");
 
-    let preblock = get_block_events(blockhash, client).await.unwrap();
+    let preblock = get_block_events(blockhash, client).await?;
 
     let extrinsics = preblock.block.extrinsics;
 

--- a/examples/examples/schedule_check.rs
+++ b/examples/examples/schedule_check.rs
@@ -11,7 +11,7 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 use libuptest::jsonrpseeclient::JsonrpseeClient;
 use libuptest::types::{event_summary, H256};
 use libuptest::ws_mod::event_watch;
-
+use libuptest::error::Error;
 // the event we want to find
 
 async fn pre_upgrade() -> bool {
@@ -25,16 +25,16 @@ async fn post_upgrade() -> bool {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> anyhow::Result<(), Error> {
     println!("Created event");
     let find_me: event_summary = event_summary {
         pallet_method: "Sudo".to_string(),
         pallet_name: "fluff".to_string(),
     };
-    let client = JsonrpseeClient::with_default_url().unwrap(); // connect to ws://127.0.0.1:9944
+    let client = JsonrpseeClient::with_default_url()?; // connect to ws://127.0.0.1:9944
     let block_limit = 200; // subscribe and check the latest 200 blocks for the events
     println!("Looking for event in the {block_limit:?} latest blocks");
-    let found_blockhash: H256 = event_watch(client, find_me, block_limit).await.unwrap(); // find our event
+    let found_blockhash: H256 = event_watch(client, find_me, block_limit).await?; // find our event
 
     // get the diff log, compare storage maps from metadata
 

--- a/examples/examples/sub_events.rs
+++ b/examples/examples/sub_events.rs
@@ -14,15 +14,15 @@ use libuptest::jsonrpseeclient::subscription::HandleSubscription;
 use libuptest::jsonrpseeclient::subscription::Subscribe;
 use libuptest::jsonrpseeclient::{JsonrpseeClient, RpcParams, SubscriptionWrapper};
 use libuptest::types::Header;
-
+use libuptest::error::Error;
 use libuptest::decode_extrinsic::{decode_extrinsic_hex_string, decodec_to_event_summary};
 use libuptest::types::{event_summary, H256};
 use libuptest::ws_mod::{blocknumber_to_blockhash, get_block_events, get_raw_metadata};
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> anyhow::Result<(), Error> {
     let wsinstance = "wss://polkadot-rpc-tn.dwellir.com:443"; // my node endpoint
-    let client: JsonrpseeClient = JsonrpseeClient::new(wsinstance).unwrap();
+    let client: JsonrpseeClient = JsonrpseeClient::new(wsinstance)?;
 
     println!("Subscribing");
     let mut subscrib: SubscriptionWrapper<Header> = client
@@ -31,24 +31,32 @@ async fn main() -> anyhow::Result<()> {
             RpcParams::new(),
             "chain_unsubscribeFinalizedHeads",
         )
-        .unwrap();
-    let metadatablob = get_raw_metadata(client.clone()).await.unwrap();
+        ?;
+    let metadatablob = get_raw_metadata(client.clone()).await?;
 
     for _ in 0..300 {
         let nextone = subscrib.next();
         println!("------------------------------------------------");
-        let myblocknr = nextone.unwrap().unwrap().number;
+        let myblocknr = match nextone {
+            Some(Ok(header)) => header.clone().number,
+            Some(Err(_err)) => {
+                return Err(Error::BlockparseError);
+            }
+            None => {
+                return Err(Error::BlockparseError);
+            }
+        };
         println!("Latest finalized block number: #{}", myblocknr);
-        let tmp_client: JsonrpseeClient = JsonrpseeClient::new(wsinstance).unwrap();
+        let tmp_client: JsonrpseeClient = JsonrpseeClient::new(wsinstance)?;
         let blockhash: H256 = blocknumber_to_blockhash(tmp_client.clone(), myblocknr.clone())
             .await
-            .unwrap();
+            ?;
         println!("Block hash: {blockhash:?}");
 
         //    let tmpblock: H256 = H256::from_str("0x17ee6d42553cf5161144ab95fecfe27c694e697f2d7e6f22271972cf476176b5").unwrap(); static polkadot block used for debugging
 
         //let tmpblock: H256 = H256::from_string("0x343f3f94ff17c79f2f4e77dcb5e894507b89dd575dbc2e36bde658ad653ead45"); //0x343f3f94ff17c79f2f4e77dcb5e894507b89dd575dbc2e36bde658ad653ead45
-        let preblock = get_block_events(blockhash, tmp_client).await.unwrap();
+        let preblock = get_block_events(blockhash, tmp_client).await?;
 
         let extrinsics = preblock.block.extrinsics;
 

--- a/examples/examples/subxt_schedule.rs
+++ b/examples/examples/subxt_schedule.rs
@@ -4,6 +4,7 @@ use libuptest::subxt_helper::tx_schedule;
 use libuptest::types::event_summary;
 use subxt::{OnlineClient, PolkadotConfig};
 use subxt_signer::sr25519::dev;
+use libuptest::error::Error;
 
 #[subxt::subxt(runtime_metadata_url = "ws://127.0.0.1:9944")]
 pub mod nodetemplate {}
@@ -11,7 +12,7 @@ pub mod nodetemplate {}
 use nodetemplate::runtime_types::sp_weights::weight_v2::Weight;
 
 #[tokio::main]
-async fn main() -> anyhow::Result<(), libuptest::error::Error> {
+async fn main() -> anyhow::Result<(), Error> {
     println!("starting");
     // wait for 100 blocks
     let block_limit: u32 = 100u32;
@@ -30,7 +31,7 @@ async fn main() -> anyhow::Result<(), libuptest::error::Error> {
     // build the subxt api
     let api = OnlineClient::<PolkadotConfig>::from_url(ws_host)
         .await
-        .unwrap();
+        ?;
     // run function
     let go = tx_schedule(from_account, api, &call, event, block_limit, ws_host).await;
     println!(

--- a/examples/examples/upgrade_change_diff.rs
+++ b/examples/examples/upgrade_change_diff.rs
@@ -14,13 +14,13 @@ use libuptest::jsonrpseeclient::JsonrpseeClient;
 use libuptest::types::{event_summary, H256};
 use libuptest::ws_mod::{event_watch, get_raw_metadata, get_runtime_version};
 use tokio::time::{sleep, Duration};
-
+use libuptest::error::Error;
 use libuptest::pallet_storage_parse::{parse_pallet_storage_types, storage_map_info};
 
 #[tokio::main]
-async fn main() -> anyhow::Result<(), libuptest::error::Error> {
-    let client = JsonrpseeClient::with_default_url().unwrap(); //.expect("Could not connect to chain");
-    let old_version = get_runtime_version(client.clone()).await.unwrap();
+async fn main() -> anyhow::Result<(), Error> {
+    let client = JsonrpseeClient::with_default_url()?; //.expect("Could not connect to chain");
+    let old_version = get_runtime_version(client.clone()).await?;
     println!(
         "Connected to: {:?}  Runtime version: {:?}",
         old_version.spec_name, old_version.spec_version
@@ -33,10 +33,10 @@ async fn main() -> anyhow::Result<(), libuptest::error::Error> {
     println!("Waiting for custom event to be triggered");
     let old_metadatablob = get_raw_metadata(client.clone()).await?;
     let old_pallet_list: Vec<storage_map_info> =
-        parse_pallet_storage_types(old_metadatablob).await.unwrap();
+        parse_pallet_storage_types(old_metadatablob).await?;
     let event_grab: Result<H256, libuptest::error::Error> =
         event_watch(client.clone(), runtime_upgrade_event, block_limit).await;
-    println!("Event detected in block: {:?}", event_grab.unwrap());
+    println!("Event detected in block: {:?}", event_grab?);
     println!("Having a coffee break before next block...");
     let duration_to_wait = Duration::new(10, 0); // chill 10 seconds
     let _ = sleep(duration_to_wait).await;
@@ -44,8 +44,8 @@ async fn main() -> anyhow::Result<(), libuptest::error::Error> {
     println!("Scanning the new metadata for changes");
     let new_metadatablob = get_raw_metadata(client.clone()).await?;
     let new_pallet_list: Vec<storage_map_info> =
-        parse_pallet_storage_types(new_metadatablob).await.unwrap();
-    let new_version = get_runtime_version(client.clone()).await.unwrap();
+        parse_pallet_storage_types(new_metadatablob).await?;
+    let new_version = get_runtime_version(client.clone()).await?;
     println!(
         "Runtime upgraded from version: {:?} to new version: {:?}",
         old_version.spec_version, new_version.spec_version

--- a/libuptest/Cargo.toml
+++ b/libuptest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libuptest"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Filip Kalebo<info@rustsyndi.cat>"]
 license = "MIT"

--- a/libuptest/README.md
+++ b/libuptest/README.md
@@ -7,9 +7,11 @@ Substrate r*U*ntime u*P*grade *TEST*ing library
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)   
 
 
-Funded by:  
+Initally funded by:  
 ![Polkadot Treasury](polkadot-treasury-logo.svg)
 
+### Latest release:
+0.1.4   
 
 ### Documentation:    
 [https://uptest-sc.github.io/](https://uptest-sc.github.io/)   

--- a/libuptest/src/error.rs
+++ b/libuptest/src/error.rs
@@ -20,12 +20,18 @@ use serde::{Deserialize, Serialize}; //boxed::Box,
 pub enum Error {
     /// Serde Json error
     SerdeJson(serde_json::error::Error),
+    /// subxt thirdparty library error
+    SubxtError(subxt::Error),
+    // reqwest thirdparty lib error
+    ReqwestError(reqwest::Error),
     MpscSend(String),
     InvalidUrl(String),
     RecvError(String),
     Io(String),
     FileIOerror(std::io::Error),
     Stderror(String),
+    // error in std::error
+    STDLIBerror,
     /// error getting block events
     ErrorEvent,
     /// Could not find event in the latest blocks
@@ -49,6 +55,8 @@ pub enum Error {
     NoMetaData,
     /// could not remove connection subscription
     Unsubscribefail,
+    /// could not parse the block
+    BlockparseError,
     /// Could not get next item in async loop
     AsyncNextError,
     /// Could not establish a subscription connection
@@ -56,6 +64,8 @@ pub enum Error {
     Client(Box<dyn core::error::Error + Send + Sync + 'static>),
     Anyhow(anyhow::Error),
 }
+
+
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -69,6 +79,13 @@ impl From<serde_json::error::Error> for Error {
         Self::SerdeJson(error)
     }
 }
+// subxt 
+impl From<subxt::Error> for Error {
+    fn from(error: subxt::Error) -> Self {
+        Self::SubxtError(error)
+    }
+}
+
 // add hex | solve the trait `From<hex::FromHexError>` is not implemented for `error::Error`
 impl From<hex::FromHexError> for Error {
     fn from(value: hex::FromHexError) -> Self {
@@ -85,6 +102,20 @@ impl From<anyhow::Error> for Error {
 impl From<std::io::Error> for Error {
     fn from(value: std::io::Error) -> Self {
         Self::FileIOerror(value)
+    }
+}
+
+impl From<Box<dyn std::error::Error>> for Error {
+    fn from(error: Box<dyn std::error::Error>) -> Self {
+        Self::Stderror(error.to_string())
+       }
+}
+
+
+
+impl From<reqwest::Error> for Error {
+    fn from(value: reqwest::Error) -> Self {
+        Self::ReqwestError(value)
     }
 }
 

--- a/libuptest/src/migration_search/crates_io_search.rs
+++ b/libuptest/src/migration_search/crates_io_search.rs
@@ -2,6 +2,7 @@ use reqwest::header::USER_AGENT;
 use serde::{Deserialize, Serialize};
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt; // for write_all()
+use crate::error::Error;
 
 /// crates.io crates.crate.links field
 #[derive(Deserialize, Serialize, Debug)]
@@ -62,7 +63,7 @@ pub struct Crates {
 pub async fn download_crate_from_crates_io(
     crate_version: String,
     crate_name: String,
-) -> Result<String, reqwest::Error> {
+) -> Result<String, Error> {
     let file_name = format!("{crate_name:}-{crate_version:}.gzip");
     //https://crates.io/api/v1/crates/serde/1.0.0/download
     let url = format!(
@@ -77,11 +78,11 @@ pub async fn download_crate_from_crates_io(
         .send()
         .await?;
     println!("crate downloaded ok");
-    let mut filen = File::create(file_name.clone()).await.unwrap();
+    let mut filen = File::create(file_name.clone()).await?;
     filen
         .write_all(&tanka.bytes().await.unwrap())
         .await
-        .unwrap();
+        ?;
     println!("crate saved as {file_name:}");
 
     Ok(file_name)

--- a/libuptest/src/pallet_storage_parse.rs
+++ b/libuptest/src/pallet_storage_parse.rs
@@ -149,11 +149,12 @@ pub async fn parse_pallet_storage_types(
                 } => {
                     pallet_info.type_id = value.id();
                     pallet_info.storage_type = storage_types::StorageMap;
-                }
-                _ => {
-                    //                println!("Could not detect storage type");
-                    pallet_info.storage_type = storage_types::Unknown;
-                }
+                } /*
+                  _ => {
+                      //                println!("Could not detect storage type");
+                      pallet_info.storage_type = storage_types::Unknown;
+                  }
+                  */
             } // set the raw_type
             for co in og_types.iter() {
                 if co.id() == pallet_info.type_id {

--- a/libuptest/src/subxt_helper.rs
+++ b/libuptest/src/subxt_helper.rs
@@ -44,10 +44,10 @@ pub async fn tx_schedule<Call: subxt::tx::TxPayload>(
         .tx()
         .sign_and_submit_then_watch_default(call, &from_account)
         .await
-        .unwrap()
+        .unwrap() // needs looking over upstreeam lib
         .wait_for_finalized_success()
         .await
-        .unwrap();
+        .unwrap(); // needs looking over upstreeam lib
     //    println!("tx sent");
     let blockhash: H256 = events.block_hash().into();
     // return the block hash that includes the executed transaction

--- a/libuptest/src/test_generation/autogen.rs
+++ b/libuptest/src/test_generation/autogen.rs
@@ -5,8 +5,7 @@ use crate::test_helper::InputHelper;
 use crate::ws_mod::get_raw_metadata;
 
 use crate::pallet_storage_parse::{
-    parse_pallet_storage_types, storage_map_info, type_id_to_type_def, TypeDef, TypeDefComposite,
-    TypeDefReg, TypeDefTuple,
+    parse_pallet_storage_types, storage_map_info, type_id_to_type_def, TypeDef, TypeDefReg,
 };
 use crate::types::storage_types;
 
@@ -105,7 +104,7 @@ pub async fn generate_auto_test(client: JsonrpseeClient) -> Result<AutoTests, Er
                 let name_type = test
                     .fields()
                     .first()
-                    .unwrap()
+                    .unwrap() // needs looking over upstream
                     .type_name()
                     .ok_or(Error::StorageItemNotFound)?; // only does first, todo: fix this to an iterating solution
                 let outputt = format!(
@@ -246,7 +245,7 @@ pub async fn generate_test_std(client: JsonrpseeClient) -> Result<(), Error> {
                 let name_type = test
                     .fields()
                     .first()
-                    .unwrap()
+                    .unwrap() // needs looking over upstream
                     .type_name()
                     .ok_or(Error::StorageItemNotFound)?; // only does first, todo: fix this to an iterating solution
                 let outputt = format!(
@@ -314,6 +313,6 @@ pub async fn generate_test_std(client: JsonrpseeClient) -> Result<(), Error> {
         println!("-------------------");
     }
 
-    /// raw type to match against the input gen
+    // raw type to match against the input gen
     Ok(())
 }

--- a/libuptest/src/test_helper.rs
+++ b/libuptest/src/test_helper.rs
@@ -1,5 +1,5 @@
 /// automatically generate
-use rand::{Rng, SeedableRng}; // https://rust-random.github.io/book/guide-rngs.html
+use rand::Rng; // https://rust-random.github.io/book/guide-rngs.html
 
 #[cfg(feature = "subxthelper")]
 use subxt_signer::sr25519::Keypair;

--- a/libuptest/src/types.rs
+++ b/libuptest/src/types.rs
@@ -36,7 +36,7 @@ impl From<subxt::utils::H256> for H256 {
 }
 
 /// Block Header containing the block nr
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Header {
     pub number: String,
 }

--- a/run_examples.sh
+++ b/run_examples.sh
@@ -1,0 +1,5 @@
+echo "running examples"
+for example in $(ls examples/examples/*.rs); do
+    example_name=$(basename $example .rs)
+    cargo run -p uptest-examples --example $example_name
+done


### PR DESCRIPTION
Improved error handling, supporting subxt, serde_json, hex, anyhow, std io, fixed_hash, std error and reqwest
no unwraps!! in core libuptest lib, however 2 unwraps due to thirdparties are in the code, one duee to the decoding lib and one due to the clap cli third party libraries
better examples
